### PR TITLE
Do not loose precision : keep a copy of original latlng

### DIFF
--- a/bouncemarker.js
+++ b/bouncemarker.js
@@ -50,13 +50,15 @@
         var delta = opts.delta(progress);
         opts.step(delta);
         if (progress === 1) {
+          opts.end();
           clearInterval(id);
         }
       }, opts.delay || 10);
     },
 
     _move: function (delta, duration) {
-      var start_point = this._drop_point.y,
+      var original = L.latLng(this._latlng),
+          start_point = this._drop_point.y,
           distance = this._point.y - start_point;
       var self = this;
 
@@ -67,6 +69,9 @@
         step: function (delta) {
           self._drop_point.y = start_point + (distance * delta);
           self.setLatLng(self._toLatLng(self._drop_point));
+        },
+        end: function () {
+          self.setLatLng(original);
         }
       });
     },


### PR DESCRIPTION
Currently, the last point of the animation is used for the final `setLatLng()` call on the marker.

This looses precision, especially if the map zoom level is low. To reproduce: bounce at zoom level 0, and zoom in to level 18: the marker position is wrong.

This patch keeps a reference to the original marker position and restores it at the end of the animation.

Since I didn't know if you were going to accept the PR https://github.com/maximeh/leaflet.bouncemarker/pull/2, I forked from your master: just tell me if you need any help for merging the two!
