### PR TITLE
bounce() is not using the actual marker's latlng

### DIFF
--- a/bouncemarker.js
+++ b/bouncemarker.js
@@ -159,7 +159,7 @@
       // location then move to its drop location, and you may be able to see it.)
       if (this.options.bounceOnAdd === true) {
         // backward compatibility
-        if (typeof this.options.bounceOnAddDuration !== 'undefined') {ori
+        if (typeof this.options.bounceOnAddDuration !== 'undefined') {
           this.options.bounceOnAddOptions.duration = this.options.bounceOnAddDuration;
         }
 


### PR DESCRIPTION
The `bounce()` method was using the original `latlng` also for markers with
an updated `latlng` (for example, changed via `setLatLng()` or after dragging it),
causing the animation happening at the wrong place.
This change adds a private `_bounce()` method that would be used by `onAdd()`,
and extends the `bounce()` method updating `_orig_latlng` with the last
marker's `latlng`.
