### PR TITLE
Fix types

### DIFF
--- a/leaflet.bouncemarker.d.ts
+++ b/leaflet.bouncemarker.d.ts
@@ -1,19 +1,23 @@
-import * as L from 'leaflet';
+import 'leaflet';
 
 declare module 'leaflet' {
 
-  export interface MarkerOptions extends InteractiveLayerOptions {
+  export type BounceOptions = {
+    duration: number;
+    height: number;
+    loop: number;
+  };
 
+  export interface MarkerOptions {
     bounceOnAdd?: boolean;
+    bounceOnAddOptions?: BounceOptions;
+    bounceOnAddCallback?: () => void;
+  }
 
-    bounceOnAddOptions?: {
-        duration: number,
-        height: number,
-        loop: number,
-    };
-
-    bounceOnAddCallback?: Function;
-
+  export interface Marker {
+    bounce(callback?: () => void): void;
+    bounce(options: BounceOptions, callback?: () => void): void;
+    stopBounce(): void;
   }
 
 }

--- a/leaflet.bouncemarker.d.ts
+++ b/leaflet.bouncemarker.d.ts
@@ -1,11 +1,10 @@
-import 'leaflet';
+import "leaflet";
 
-declare module 'leaflet' {
-
+declare module "leaflet" {
   export type BounceOptions = {
-    duration: number;
-    height: number;
-    loop: number;
+    duration?: number;
+    height?: number;
+    loop?: number;
   };
 
   export interface MarkerOptions {
@@ -19,5 +18,4 @@ declare module 'leaflet' {
     bounce(options: BounceOptions, callback?: () => void): void;
     stopBounce(): void;
   }
-
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "Make a marker bounce when you add it to a map.",
   "main": "bouncemarker.js",
+  "types": "leaflet.bouncemarker.d.ts",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Simplify import
- Add methods: `bounce()` and `stopBounce()`
- Replace `Function` with `() => void`
- Make all options optional
- Add `"types"` to **package.json**, for types to automatically be picked up by TypeScript

Closes #40 