### PR TITLE
bouncemarker.js: save original marker position in `bounce()`

### DIFF
--- a/bouncemarker.js
+++ b/bouncemarker.js
@@ -136,7 +136,8 @@
         options.height = arguments[1];
       }
 
-      // Keep original map center
+      // Keep original latitude, longitude and map center
+      this._origLatlng = this.getLatLng();
       this._origMapCenter = this._map.project(this._map.getCenter());
       this._dropPoint = this._getDropPoint(options.height);
       this._bounceMotion(options, endCallback);
@@ -168,9 +169,6 @@
 
       // Call leaflet original method to add the Marker to the map.
       originalOnAdd.call(this, map);
-
-      // Keep original latitude and longitude
-      this._origLatlng = this.getLatLng();
 
       if (this.options.bounceOnAdd === true) {
         this.bounce(this.options.bounceOnAddOptions, this.options.bounceOnAddCallback);


### PR DESCRIPTION
Fixes moved markers bouncing at wrong position.

AFAICT from manual testing this doesn't change the current behavior when zooming in/out or panning the map.

If the current behavior is optimal is another question. E.g. should the drop point be re-calculated with panning? Most of the time, the bouncing marker seems to disappear when zooming in and out, until bouncing is complete or the original zoom level is restored. But as I said, that seems to be the case even before this change.

It would be preferable if the bouncing would be independent of zooming and/or panning. I.e. it should always drop the same distance in _pixels_ on the screen. If that's achievable or not, I'm not invested enough to tell at the moment. Just food for thought.

However, since at least zooming in/out leaves a far from optimal experience, I would consider stopping the animation if the zoom level changes. At least until the zooming stops, then it might be desirable to restart it (re-calculating the starting values).

But I guess that could be left up to the user as well.

Fixes #39. 