### PR TITLE
onRemove(): only restore original position if set

### DIFF
--- a/bouncemarker.js
+++ b/bouncemarker.js
@@ -146,7 +146,9 @@
     stopBounce: function(){
       // We may have modified the marker; so we need to place it where it
       // belongs so next time its coordinates are not changed.
-      this.setLatLng(this._origLatlng);
+      if (typeof this._origLatlng !== "undefined") {
+        this.setLatLng(this._origLatlng);
+      }
       L.Util.cancelAnimFrame(this._animationId);
     },
 


### PR DESCRIPTION
If the marker is never bounced, the original position is never stored.

Trying to set the position to `undefined` throws an error.

This behavior is a consequence of #42.